### PR TITLE
fix: fix a crash when adding a plugin without monitoring

### DIFF
--- a/src/main/PluginsConfigurator.h
+++ b/src/main/PluginsConfigurator.h
@@ -167,7 +167,7 @@ public:
         /**
          *
          */
-        bool mWithPluginMonitoring;
+        bool mWithPluginMonitoring = false;
 
         /**
          *
@@ -177,7 +177,7 @@ public:
         /**
          *
          */
-        bool mWithReaderMonitoring;
+        bool mWithReaderMonitoring = false;
 
         /**
          *


### PR DESCRIPTION
Lorsque l'on ajoute un plugin sans monitoring, les variables `mWithPluginMonitoring` et `mWithReaderMonitoring` n'étaient pas initialisée, ce qui rend le comportement de `CardResourceServiceAdapter::startMonitoring` non déterministe.